### PR TITLE
Replace int with int64 in literal type

### DIFF
--- a/lib/quickcheck_infra.ml
+++ b/lib/quickcheck_infra.ml
@@ -24,7 +24,7 @@ let quickcheck_generator_literal : literal Generator.t =
   let open Let_syntax in
   weighted_union
     [
-      (0.8, small_strictly_positive_int >>| fun i -> LitInt i);
+      (0.8, small_strictly_positive_int >>| fun i -> LitInt (Int64.of_int i));
       (0.2, [%quickcheck.generator: bool] >>| fun b -> LitBool b);
     ]
 


### PR DESCRIPTION
Use OCaml's `int64` type instead of `int` to represent Bril ints, since Bril uses 64-bit ints. 
Updated JSON serialization functions + QuickCheck generators to handle int64, passed QuickCheck tests.

